### PR TITLE
support us region by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ Handy terraform scripts for running TiDB on AWS
 ### Quick Start
 1. git clone this project，and execute `terraform init`
 2. modify variables.tf, fill with your aws_access_key and aws_secret_key, and the cluster topology
-3. execute `terraform plan` 
+3. execute `terraform plan`
 4. Make sure terraform generates right plan, and execute `terraform apply`
 5. After Step 4, you can see the public IP of relay-server，ssh to the replay-server, the tidb-ansible directory will be on /home/ec2-user/tidb-ansible
 6. find `# ssh_args = -i aws.key -C -o ControlMaster=auto -o ControlPersist=60s`, remove the comment mark, and deploy tidb using tidb-ansible.
+7. execute `terraform destroy` to destroy all resources when you do not need to use these resources
 
 ### Resource Overview
 1. Deploy region
 
-	* cn-northwest-1
+	* us-east-1
 
 2. Default EC2 instance type
 
@@ -49,3 +50,26 @@ Handy terraform scripts for running TiDB on AWS
 
 9. Generating Template File for TiDB ansible
 	* Generate [TiDB-Ansible](https://github.com/pingcap/tidb-ansible) 's inventory.ini
+
+### Query AMI information
+1. First refer to this [document](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) to install the AWS cli tool.
+2. Configure the local AWS cli tool, ~/.aws/config is configured as follows:
+
+```
+[default]
+region=us-east-1  # Fill in the name of region you need to operate.
+output=json
+```
+touch ~/.aws/credentials, fill with your aws_access_key and aws_secret_key as follows:
+
+ ```
+[default]
+aws_access_key_id=xxx
+aws_secret_access_key=xxx
+```
+3. Execute the following command after the above steps are completed.
+
+```shell
+aws ec2 describe-images --filters "Name=name,Values=amzn2-ami-hvm-*" "Name=virtualization-type,Values=hvm"
+```
+Select an AMI from the returned AMI list, modify main.tf file and fill in the `OwnerId` value in the list of owners fields in the `data "aws_ami" "distro"`.

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ data "aws_ami" "distro" {
     values = ["hvm"]
   }
 
-  owners = ["141808717104"] #Amazon Linux 2
+  owners = ["137112412989"] #Amazon Linux 2
 }
 
 resource "aws_instance" "bastion" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,17 @@
 variable "aws_access_key" {
   type        = "string"
   description = "Your AWS access key id"
-  default     = ""
 }
 
 variable "aws_secret_key" {
   type        = "string"
   description = "Your AWS secret key"
-  default     = ""
 }
 
 variable "aws_region" {
   type        = "string"
   description = "The AWS region you want to create resources"
-  default     = "cn-northwest-1"
+  default     = "us-east-1"
 }
 
 variable "public_subnets" {


### PR DESCRIPTION
- support launch EC2 instances in US region by default
- update README.md, added a way to get different region's AMI owerId and how to destroy all resources
- remove the default access credential option of aws.

@c4pt0r  PTAL